### PR TITLE
Fix Debian arm64 cross-compilation build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,15 +92,10 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             arch: amd64
-            # No specific linker needed for amd64 on amd64 runner
           - target: aarch64-unknown-linux-gnu
             arch: arm64
-            linker: aarch64-linux-gnu-gcc
-            rustflags: '["-C", "target-feature=+crt-static"]'
           - target: armv7-unknown-linux-gnueabihf
             arch: armhf
-            linker: '/opt/rpi_tools/arm-bcm2708/arm-rpi-4.9.3-linux-gnueabihf/bin/arm-linux-gnueabihf-gcc'
-            rustflags: '["-C", "target-feature=+crt-static"]'
 
     steps:
       - name: Checkout repository
@@ -141,67 +136,33 @@ jobs:
 
           EOF
           sudo apt update -qq
-      - name: Install compilation dependencies (for amd64)
-        if: matrix.arch == 'amd64'
+      - name: Install build dependencies
         run: |
-          sudo apt install -y --no-install-recommends debhelper-compat rustup pkg-config \
-           libstdc++-13-dev libcec-dev libudev-dev
-          rustup -q default stable
-          rustup -q update
-
-      - name: Install cross-compilation dependencies (for ARMhf)
-        if: matrix.arch == 'armhf'
-        run: |
-          sudo dpkg --add-architecture ${{ matrix.arch }}
-          sudo apt update -qq
-          sudo apt install -y --no-install-recommends \
-            debhelper-compat rustup pkg-config gcc-arm-linux-gnueabihf libc6-dev-armhf-cross \
-            libstdc++-13-dev-armhf-cross libcec-dev:${{ matrix.arch }} libudev-dev:${{ matrix.arch }}
-          mkdir -p /opt
-          # Download and extract Raspberry Pi cross-compilation tools
-          git clone https://github.com/raspberrypi/tools /opt/rpi_tools
-          rustup target add ${{ matrix.target }}
-          rustup -q default stable
-          rustup -q update
-
-      - name: Install cross-compilation dependencies (for ARM64)
-        if: matrix.arch == 'arm64'
-        run: |
-          sudo dpkg --add-architecture ${{ matrix.arch }}
-          sudo apt update -qq
-          sudo apt install -y --no-install-recommends \
-            debhelper-compat rustup pkg-config  gcc-aarch64-linux-gnu libc6-dev-arm64-cross \
-            libstdc++-13-dev-arm64-cross libcec-dev:${{ matrix.arch }} libudev-dev:${{ matrix.arch }}
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends dpkg-dev build-essential
+          if [ "${{ matrix.arch }}" = "arm64" ]; then
+            sudo dpkg --add-architecture arm64
+            sudo apt-get update -qq
+            sudo apt-get install -y --no-install-recommends \
+              gcc-aarch64-linux-gnu \
+              libc6-dev-arm64-cross \
+              libstdc++-13-dev-arm64-cross
+          fi
+          if [ "${{ matrix.arch }}" = "armhf" ]; then
+            sudo dpkg --add-architecture armhf
+            sudo apt-get update -qq
+            sudo apt-get install -y --no-install-recommends \
+              gcc-arm-linux-gnueabihf \
+              libc6-dev-armhf-cross \
+              libstdc++-13-dev-armhf-cross
+            mkdir -p /opt
+            git clone https://github.com/raspberrypi/tools /opt/rpi_tools
+          fi
           rustup target add ${{ matrix.target }}
           rustup -q default stable
           rustup -q update
 
       - name: Build Debian package for ${{ matrix.arch }}
-        if: matrix.arch != 'armhf' && matrix.arch != 'arm64'
-        run: dpkg-buildpackage -b -d -uc -us --host-arch ${{ matrix.arch }}
-
-      - name: Build Debian package for armhf
-        if: matrix.arch == 'armhf'
-        env:
-          # Set target for cross-compilation
-          CARGO_BUILD_TARGET: ${{ matrix.target }}
-          # For armhf specifically, ensure we use the right target features
-          CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER: 'arm-linux-gnueabihf-gcc'
-          # PKG_CONFIG settings for cross-compilation
-          PKG_CONFIG_ALLOW_CROSS: 1
-          PKG_CONFIG_PATH: '/usr/lib/arm-linux-gnueabihf/pkgconfig'
-        run: dpkg-buildpackage -b -d -uc -us --host-arch ${{ matrix.arch }}
-
-      - name: Build Debian package for arm64
-        if: matrix.arch == 'arm64'
-        env:
-          # Set target for cross-compilation
-          CARGO_BUILD_TARGET: ${{ matrix.target }}
-          # For armhf specifically, ensure we use the right target features
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: 'aarch64-linux-gnu-gcc'
-          # PKG_CONFIG settings for cross-compilation
-          PKG_CONFIG_ALLOW_CROSS: 1
-          PKG_CONFIG_PATH: '/usr/lib/aarch64-linux-gnu/pkgconfig'
         run: dpkg-buildpackage -b -d -uc -us --host-arch ${{ matrix.arch }}
 
       - name: Get package name and path

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: cec2uinput
 Section: misc
 Priority: optional
 Maintainer: Quintus Leung <quintusl@gmail.com>
-Build-Depends: debhelper (>= 13), pkg-config, rustup, libcec-dev, libudev-dev
+Build-Depends: debhelper (>= 13), pkg-config, cargo, rustc, libcec-dev (>= 6.0.2) | libcec-dev:any, libudev-dev | libudev-dev:any
 Standards-Version: 4.5.0
 Homepage: https://github.com/quintusl/cec2uinput
 

--- a/debian/rules
+++ b/debian/rules
@@ -4,19 +4,24 @@
 	dh $@
 
 override_dh_auto_build:
-ifdef CARGO_BUILD_TARGET
-	cargo build --release --target $(CARGO_BUILD_TARGET)
-else
-	cargo build --release
-endif
+	# Set Rust flags and target for cross-compilation
+	if [ -n "${DEB_HOST_ARCH}" ]; then \
+		export CARGO_BUILD_TARGET=$$(case "${DEB_HOST_ARCH}" in \
+			"amd64") echo "x86_64-unknown-linux-gnu" ;; \
+			"arm64") echo "aarch64-unknown-linux-gnu" ;; \
+			"armhf") echo "armv7-unknown-linux-gnueabihf" ;; \
+			*) echo "unsupported-architecture" ;; \
+		esac); \
+		export RUSTFLAGS="${RUSTFLAGS} -C linker=$$(case "${DEB_HOST_ARCH}" in \
+			"amd64") echo "gcc" ;; \
+			"arm64") echo "aarch64-linux-gnu-gcc" ;; \
+			"armhf") echo "arm-linux-gnueabihf-gcc" ;; \
+		esac)"; \
+	fi
+	dh_auto_build
 
 override_dh_auto_install:
-	install -d debian/cec2uinput/usr/bin
-ifdef CARGO_BUILD_TARGET
-	install -D -m755 target/$(CARGO_BUILD_TARGET)/release/cec2uinput debian/cec2uinput/usr/bin/cec2uinput
-else
-	install -D -m755 target/release/cec2uinput debian/cec2uinput/usr/bin/cec2uinput
-endif
+	dh_auto_install
 	install -d debian/cec2uinput/etc
 	install -d debian/cec2uinput/etc/cec2uinput
 	install -m 640 config/config.yml debian/cec2uinput/etc/cec2uinput/config.yml


### PR DESCRIPTION
The Debian arm64 build was failing during cross-compilation due to the linker and other rustflags not being correctly passed to the cargo build process.

This commit fixes the issue by:
- Moving the cross-compilation logic into `debian/rules`, which now sets the `CARGO_BUILD_TARGET` and `RUSTFLAGS` based on the `DEB_HOST_ARCH` variable.
- Updating `debian/control` to use architecture-qualified dependencies, making the dependency resolution more robust for cross-compilation.
- Simplifying the GitHub Actions workflow by removing the redundant environment variables and build steps, as the logic is now handled by the Debian packaging scripts.